### PR TITLE
only build payload query for valid values

### DIFF
--- a/lib/discourse_sso/single_sign_on.rb
+++ b/lib/discourse_sso/single_sign_on.rb
@@ -90,7 +90,7 @@ module DiscourseSSO
         end
       end
 
-      Rack::Utils.build_query(payload)
+      Rack::Utils.build_query(payload.select {|k, v| v.present? })
     end
   end
 end


### PR DESCRIPTION
Invalid or empty string could break discourse SSO, especially the empty avatar_url would break when discourse will try to fetch images .
